### PR TITLE
Add passives :panda_face:

### DIFF
--- a/_core.lsl
+++ b/_core.lsl
@@ -59,6 +59,7 @@
 #include "./classes/got Potions.lsl"
 #include "./classes/got RootAux.lsl"
 #include "./classes/got ModInstall.lsl"
+#include "./classes/got Passives.lsl"
 
 // Helper function to run code on all players. Requires players to be stored in a global list named PLAYERS
 #define runOnPlayers(pkey, code) {integer i; for(i=0; i<llGetListLength(PLAYERS); i++){key pkey = llList2Key(PLAYERS, i); code}}

--- a/classes/got FXCompiler.lsl
+++ b/classes/got FXCompiler.lsl
@@ -2,18 +2,31 @@
 
 #define FXCFlag$STUNNED 1
 
-#define FXCEvt$update 1					// Array of below values
-	#define FXCUpd$FLAGS 0 
-	#define FXCUpd$MANA_REGEN 1
-	#define FXCUpd$DAMAGE_DONE 2
-	#define FXCUpd$DAMAGE_TAKEN 3
-	#define FXCUpd$DODGE 4
-	#define FXCUpd$CASTTIME 5
-	#define FXCUpd$COOLDOWN 6
-	#define FXCUpd$MANACOST 7
-	#define FXCUpd$CRIT 8
-	#define FXCUpd$PAIN_MULTI 9
-	#define FXCUpd$AROUSAL_MULTI 10
+// When you add something here, make sure you also set it as a default in got Passives global var: list compiled_actives;
+#define FXCEvt$update 1					// Only sent in NPCs, in PCs the effects are tunneled through got Passives
+	#define FXCUpd$UNSET_FLAGS -1		// Special case only used when setting got Passives 
+	#define FXCUpd$FLAGS 0 				// (int)flags - Default 0
+	#define FXCUpd$MANA_REGEN 1			// (float)multiplier - Default 1
+	#define FXCUpd$DAMAGE_DONE 2		// (float)multiplier - Default 1
+	#define FXCUpd$DAMAGE_TAKEN 3		// (float)multiplier - Default 1
+	#define FXCUpd$DODGE 4				// (float)multiplier - Default 0
+	#define FXCUpd$CASTTIME 5			// (float)multiplier - Default 1
+	#define FXCUpd$COOLDOWN 6			// (float)multiplier - Default 1
+	#define FXCUpd$MANACOST 7			// (float)multiplier - Default 1
+	#define FXCUpd$CRIT 8				// (float)multiplier - Default 0
+	#define FXCUpd$PAIN_MULTI 9			// (float)multiplier - Default 1
+	#define FXCUpd$AROUSAL_MULTI 10		// (float)multiplier - Default 1
+	
+	#define FXCUpd$HP_ADD 11			// (int)hp - Default 0
+	#define FXCUpd$HP_MULTIPLIER 12		// (float)multiplier - Default 1
+	#define FXCUpd$MANA_ADD 13			// (int)mana - Default 0
+	#define FXCUpd$MANA_MULTIPLIER 14	// (float)multiplier - Default 1
+	#define FXCUpd$AROUSAL_ADD 15		// (int)arousal - Default 0
+	#define FXCUpd$AROUSAL_MULTIPLIER 16// (float)multiplier - Default 1
+	#define FXCUpd$PAIN_ADD 17			// (int)pain - Default 1
+	#define FXCUpd$PAIN_MULTIPLIER 18	// (float)multiplier - Default 1
+	
+	
 	
 #define FXCEvt$pullStart 2				// void - Pull has started
 #define FXCEvt$pullEnd 3				// void - A pull effect has ended

--- a/classes/got Passives.lsl
+++ b/classes/got Passives.lsl
@@ -1,0 +1,19 @@
+#define PassivesMethod$set 1							// (str)name, (arr)[(int)attributeid1, (var)attributeval1...] - Sets a passive with name
+#define PassivesMethod$rem 2							// (str)name - Removes a passive by name
+#define PassivesMethod$get 3							// void - Returns a list of passives affecting the player
+#define PassivesMethod$setActive 4						// (arr)actives - Sent from got FXCompiler, sends active effects flattened array to be merged with passives
+
+// The passives attributes should match got FXCompiler update attributes
+
+#define PassivesEvt$data 1								// Contains FXCUpd values from got FXCompiler.lsl
+
+#define Passives$toFloat(val) ((float)val/100)			// Convert back to float
+
+#define Passives$set(targ, name, passives) runMethod((string)targ, "got Passives", PassivesMethod$set, [name, mkarr(passives)], TNN)
+#define Passives$rem(targ, name) runMethod((string)targ, "got Passives", PassivesMethod$set, [name], TNN)
+#define Passives$get(targ, callback) runMethod((string)targ, "got Passives", PassivesMethod$get, [], callback)
+#define Passives$setActive(active) runMethod((string)LINK_ROOT, "got Passives", PassivesMethod$setActive, [mkarr(active)], TNN)
+
+
+
+

--- a/classes/packages/got FX.lsl
+++ b/classes/packages/got FX.lsl
@@ -17,10 +17,14 @@ float dodge_add;
 onEvt(string script, integer evt, string data){
     // Packages to work on
 if(script != cls$name){
-    if(script == "got FXCompiler"){
-		if(evt == FXCEvt$update){
-			dodge_chance = (float)jVal(data, [4]);
-		}
+    if(
+		#ifndef IS_NPC
+		script == "got Passives" && evt == PassivesEvt$data
+		#else
+		script == "got FXCompiler" && evt == FXCEvt$update
+		#endif
+	){
+		dodge_chance = (float)jVal(data, [4]);
 	}
 	else if(script == "got Bridge"){
         if(evt == BridgeEvt$data_change){

--- a/classes/packages/got FXCompiler_PC.lsl
+++ b/classes/packages/got FXCompiler_PC.lsl
@@ -181,7 +181,6 @@ remEffect(key caster, integer stacks, string package, integer pid, integer overw
 
 
 
-	
 
 updateGame(){
     integer visual = llList2Integer(THONG_VISUALS, -2);
@@ -233,8 +232,9 @@ updateGame(){
         else spdmtm+=[n, 1+llList2Float(SPELL_DMG_TAKEN_MOD, i+2)];
     }
     
-    Status$spellModifiers(spdmtm);
-    raiseEvent(FXCEvt$update, mkarr(([CACHE_FLAGS, regen, ddm, dtm, dodge, ctm, cdm, mcm, cm, pm, am])));
+    Status$spellModifiers(spdmtm); 
+	
+	Passives$setActive(([CACHE_FLAGS, regen, ddm, dtm, dodge, ctm, cdm, mcm, cm, pm, am]));
 }
 
 #include "got/classes/packages/got FXCompiler.lsl"

--- a/classes/packages/got FX_PC.lsl
+++ b/classes/packages/got FX_PC.lsl
@@ -13,7 +13,7 @@ key _NPC_TARG;
 
 
 evtListener(string script, integer evt, string data){
-    if(script == "got FXCompiler" && evt == FXCEvt$update)FX_FLAGS = (integer)jVal(data, [0]);
+    if(script == "got Passives" && evt == PassivesEvt$data)FX_FLAGS = (integer)jVal(data, [0]);
     else if(script == "got Status"){
         if(evt == StatusEvt$flags)STATUS = (integer)data;
         else if(evt == StatusEvt$dead && (integer)data)FX$rem(FALSE, "", "", "", 0, FALSE, PF_DETRIMENTAL, 0, 0);

--- a/classes/packages/got GUI.lsl
+++ b/classes/packages/got GUI.lsl
@@ -75,24 +75,20 @@ onEvt(string script, integer evt, string data){
             toggle(TRUE);
         }
     }
-	else if(script == "got FXCompiler"){
-		if(evt == FXCEvt$update){
-			integer flags = (integer)j(data, 0);
-			if(flags == CACHE_FX_FLAGS)return;
-			
-			
-			if(
-				(flags&fx$F_BLINDED && ~CACHE_FX_FLAGS&fx$F_BLINDED) ||
-				(~flags&fx$F_BLINDED && CACHE_FX_FLAGS&fx$F_BLINDED)
-			){
-				integer on;
-				if(flags&fx$F_BLINDED)on = TRUE;
-				list data = [PRIM_POSITION, BLIND_POS, PRIM_SIZE, BLIND_SCALE];
-				if(!on)data = [PRIM_POSITION, ZERO_VECTOR, PRIM_SIZE, ZERO_VECTOR];
-				llSetLinkPrimitiveParams(P_BLIND, data);
-			}
-			CACHE_FX_FLAGS = flags;
+	else if(script == "got Passives" && evt == PassivesEvt$data){
+		integer flags = (integer)j(data, 0);
+		if(flags == CACHE_FX_FLAGS)return;
+		if(
+			(flags&fx$F_BLINDED && ~CACHE_FX_FLAGS&fx$F_BLINDED) ||
+			(~flags&fx$F_BLINDED && CACHE_FX_FLAGS&fx$F_BLINDED)
+		){
+			integer on;
+			if(flags&fx$F_BLINDED)on = TRUE;
+			list data = [PRIM_POSITION, BLIND_POS, PRIM_SIZE, BLIND_SCALE];
+			if(!on)data = [PRIM_POSITION, ZERO_VECTOR, PRIM_SIZE, ZERO_VECTOR];
+			llSetLinkPrimitiveParams(P_BLIND, data);
 		}
+		CACHE_FX_FLAGS = flags;
 	}
 }
 

--- a/classes/packages/got Monster.lsl
+++ b/classes/packages/got Monster.lsl
@@ -240,11 +240,9 @@ onEvt(string script, integer evt, string data){
         LocalConf$ini();
     }
     
-    else if(script == "got FXCompiler"){
-        if(evt == FXCEvt$update){
-			FXFLAGS = (integer)j(data, 0);
-			if(FXFLAGS&(fx$F_STUNNED|fx$F_ROOTED))toggleMove(FALSE);
-        }
+    else if(script == "got FXCompiler" && evt == FXCEvt$update){
+		FXFLAGS = (integer)j(data, 0);
+		if(FXFLAGS&(fx$F_STUNNED|fx$F_ROOTED))toggleMove(FALSE);
     }
     
     else if(script == "got LocalConf" && evt == LocalConfEvt$iniData){

--- a/classes/packages/got NPCSpells.lsl
+++ b/classes/packages/got NPCSpells.lsl
@@ -94,16 +94,13 @@ updateText(){
 }
 
 onEvt(string script, integer evt, string data){
-    if(script == "got FXCompiler"){
-        if(evt == FXCEvt$update){
-            FXFLAGS = (integer)j(data, FXCUpd$FLAGS);
-            fxModDmgDone = (float)j(data, FXCUpd$DAMAGE_DONE);
-            fxCTM = (float)j(data, FXCUpd$CASTTIME); 
-            fxCDM = (float)j(data, FXCUpd$COOLDOWN);
-            if(BFL&BFL_CASTING && FXFLAGS&fx$NOCAST)
-                endCast(FALSE);
-            
-        }
+    if(script == "got FXCompiler" && evt == FXCEvt$update){
+        FXFLAGS = (integer)j(data, FXCUpd$FLAGS);
+        fxModDmgDone = (float)j(data, FXCUpd$DAMAGE_DONE);
+        fxCTM = (float)j(data, FXCUpd$CASTTIME); 
+        fxCDM = (float)j(data, FXCUpd$COOLDOWN);
+        if(BFL&BFL_CASTING && FXFLAGS&fx$NOCAST)
+            endCast(FALSE);
     }
     else if(script == "got Monster"){
         if(evt == MonsterEvt$runtimeFlagsChanged){

--- a/classes/packages/got Passives.lsl
+++ b/classes/packages/got Passives.lsl
@@ -1,0 +1,177 @@
+//#define USE_EVENTS
+list PASSIVES;
+// (str)name, (int)length, (int)attributeID, (float)attributeVal
+#define COMPILATION_STRIDE 2
+list compiled_passives;     // Compiled passives [id, val, id2, val2...]
+// This should correlate to the values in fxcevt$update
+list compiled_actives = [0,1,1,1,0,1,1,1,0,1,1,0,1,0,1,0,1,0,1];      // Compiled actives defaults
+
+/*
+    Converts a name into a position
+*/
+integer findPassiveByName(string name){
+    integer i;
+    while(i<llGetListLength(PASSIVES)){
+        if(llList2String(PASSIVES, i) == name)
+            return i;
+        i+=llList2Integer(PASSIVES, i+1);
+    }
+    return -1;
+}
+
+/*
+    Removes a passive by name
+*/
+removePassiveByName(string name){
+    integer pos = findPassiveByName(name);
+    if(~pos){
+        integer ln = llList2Integer(PASSIVES, pos+1);
+        PASSIVES = llDeleteSubList(PASSIVES, pos, pos+ln-1);
+    }
+}
+
+compilePassives(){
+    
+    list keys = [];         // Stores the attribute IDs
+    list vals = [];         // Stores the attribute values
+    integer i;
+    while(i<llGetListLength(PASSIVES)){
+        // Get the effects
+        list block = llList2List(PASSIVES, i+2, i+llList2Integer(PASSIVES, i+1)-1);
+        i+=llList2Integer(PASSIVES, i+1);
+        
+        integer x;
+        for(x = 0; x<llGetListLength(block); x+=2){
+            integer id = llList2Integer(block, x);
+            float val = llList2Float(block, x+1);
+            
+            integer pos = llListFindList(keys, [id]);
+            // The key already exists, add!
+            if(~pos)
+                vals = llListReplaceList(vals, [llList2Float(vals, pos)+val], pos, pos);
+            else{
+                keys += id;
+                vals += val;
+            }
+        }
+    }
+    
+    // These need to match compilation stride
+    compiled_passives = [];
+    for(i=0; i<llGetListLength(keys); i++){
+        list v = llList2List(vals, i, i);
+        if(llList2Float(v,0) == (float)llList2Integer(v,0))v = [llList2Integer(v,0)];
+        compiled_passives+= [llList2Integer(keys, i)]+v;
+    }
+    
+    output();
+}
+
+
+output(){
+    // Output the same event as FXCEvt$update
+    list output = compiled_actives;
+    
+    
+    integer set_flags = llList2Integer(output, FXCUpd$FLAGS);
+    integer unset_flags;
+    
+    
+    // Fields that should be treated as ints for shortening
+    list INT_FIELDS = [
+        FXCUpd$HP_ADD,
+        FXCUpd$MANA_ADD,
+        FXCUpd$AROUSAL_ADD,
+        FXCUpd$PAIN_ADD
+    ];
+    
+    integer i;
+    for(i=0; i<llGetListLength(compiled_passives); i+=COMPILATION_STRIDE){
+        integer type = llList2Integer(compiled_passives, i);
+    
+        // Cache the flags first so unset_flags can properly override
+        if(type == FXCUpd$FLAGS)
+            set_flags = set_flags|llList2Integer(compiled_passives,i+1);
+        else if(type == FXCUpd$UNSET_FLAGS)
+            unset_flags = unset_flags|llList2Integer(compiled_passives,i+1);
+        else{
+            list v = [llList2Float(compiled_passives, i+1)+llList2Float(output,type)];
+            if(~llListFindList(INT_FIELDS, [type]))v = llListReplaceList(v, [llList2Integer(v,0)], 0, 0);
+            output = llListReplaceList(output, v, type, type);
+        }
+    }
+    
+    set_flags = set_flags&~unset_flags;
+    output = llListReplaceList(output, [set_flags], FXCUpd$FLAGS, FXCUpd$FLAGS);
+    
+    string out = mkarr(output);
+    raiseEvent(PassivesEvt$data, out);
+
+}
+
+
+default
+{
+    state_entry()
+    {
+        
+    }
+    
+    #include "xobj_core/_LM.lsl" 
+    if(method$isCallback){
+        return;
+    }
+    
+    
+    /*
+        Adds a passive
+    */
+    if(METHOD == PassivesMethod$set){
+        string name = method_arg(0);
+        list effects = llJson2List(method_arg(1));
+        
+        // Find if passive exists and remove it
+        removePassiveByName(name);
+        
+        // Go through the index
+        if((llGetListLength(effects)%2) == 1)qd("Warning: Passives have an uneven index: "+name);
+        PASSIVES += [name, llGetListLength(effects)+2]+effects;
+        compilePassives();
+    }
+    
+    
+    /*
+        Removes a passive
+    */
+    else if(METHOD == PassivesMethod$rem){
+        string name = method_arg(0);
+        removePassiveByName(name);
+        compilePassives();
+    }
+    
+    /*
+        Returns a list of passive names
+    */
+    else if(METHOD == PassivesMethod$get){
+        
+        integer i;
+        while(i<llGetListLength(PASSIVES)){
+            CB_DATA += [llList2String(PASSIVES, i)];
+            i+=llList2Integer(PASSIVES, i+1);
+        }
+        
+    }
+    
+    /*
+        The active effects have changed, we recompile the list and send it out
+    */
+    else if(METHOD == PassivesMethod$setActive){
+        list set = llJson2List(method_arg(0));
+        compiled_actives = llListReplaceList(compiled_actives, set, 0, llGetListLength(set)-1);
+        output();
+    }
+
+    
+    #define LM_BOTTOM  
+    #include "xobj_core/_LM.lsl"  
+}

--- a/classes/packages/got SpellAux.lsl
+++ b/classes/packages/got SpellAux.lsl
@@ -115,7 +115,7 @@ onEvt(string script, integer evt, string data){
 			)
 		}
 	}
-    else if(script == "got FXCompiler" && evt == FXCEvt$update){
+    else if(script == "got Passives" && evt == PassivesEvt$data){
         dmdmod = (float)j(data, FXCUpd$DAMAGE_DONE);
 		critmod = (float)j(data, FXCUpd$CRIT);
 	}

--- a/classes/packages/got SpellMan.lsl
+++ b/classes/packages/got SpellMan.lsl
@@ -140,7 +140,7 @@ onEvt(string script, integer evt, string data){
     }
 	
 	// Cache FX flags
-	else if(script == "got FXCompiler" && evt == FXCEvt$update){
+	else if(script == "got Passives" && evt == PassivesEvt$data){
         ctm = (float)j(data, FXCUpd$CASTTIME);
         cdm = (float)j(data, FXCUpd$COOLDOWN);
         mcm = (float)j(data, FXCUpd$MANACOST);

--- a/classes/packages/got Status.lsl
+++ b/classes/packages/got Status.lsl
@@ -5,10 +5,10 @@
 
 #define saveFlags() db2$set([StatusShared$flags], (string)STATUS_FLAGS); raiseEvent(StatusEvt$flags, (string)STATUS_FLAGS)
 
-#define maxDurability() (DEFAULT_DURABILITY*(1+(float)getBonusStat(STAT_DURABILITY)*.1))
-#define maxMana() (DEFAULT_MANA*(1+(float)getBonusStat(STAT_MANA)*.1))
-#define maxArousal() (DEFAULT_AROUSAL*(1+(float)getBonusStat(STAT_AROUSAL)*0.5))
-#define maxPain() (DEFAULT_PAIN*(1+(float)getBonusStat(STAT_PAIN)*0.5))
+#define maxDurability() ((DEFAULT_DURABILITY+fxModMaxHpNr)*(1+(float)getBonusStat(STAT_DURABILITY)*.1)*fxModMaxHpPerc)
+#define maxMana() ((DEFAULT_MANA+fxModMaxManaNr)*(1+(float)getBonusStat(STAT_MANA)*.1)*fxModMaxManaPerc)
+#define maxArousal() ((DEFAULT_AROUSAL+fxModMaxArousalNr)*(1+(float)getBonusStat(STAT_AROUSAL)*0.5)*fxModMaxArousalPerc)
+#define maxPain() ((DEFAULT_PAIN+fxModMaxPainNr)*(1+(float)getBonusStat(STAT_PAIN)*0.5)*fxModMaxPainPerc)
 
 #define TIMER_REGEN "a"
 #define TIMER_BREAKFREE "b"
@@ -45,6 +45,17 @@ float fxModDmgTaken = 1;
 float fxModManaRegen = 1;
 float fxModArousalTaken = 1;
 float fxModPainTaken = 1;
+
+float fxModMaxHpPerc = 1;
+integer fxModMaxHpNr = 0;
+float fxModMaxManaPerc = 1;
+integer fxModMaxManaNr = 0;
+float fxModMaxArousalPerc = 1;
+integer fxModMaxArousalNr = 0;
+float fxModMaxPainPerc = 1;
+integer fxModMaxPainNr = 0;
+
+
 
 list SPELL_DMG_TAKEN_MOD;
 
@@ -230,23 +241,33 @@ float spdmtm(string spellName){
 
 
 onEvt(string script, integer evt, string data){
-    if(script == "got FXCompiler"){
-        if(evt == FXCEvt$update){
-            FXFLAGS = (integer)jVal(data, [0]);
-			
-			integer divisor = 0;
-			if(FXFLAGS&fx$F_BLURRED){
-				divisor = 8;
-			}
-			llOwnerSay("@setdebug_renderresolutiondivisor:"+(string)divisor+"=force");
-			
-            fxModDmgTaken = (float)j(data, FXCUpd$DAMAGE_TAKEN);
-            fxModManaRegen = (float)j(data, FXCUpd$MANA_REGEN);
-			fxModPainTaken = (float)j(data,FXCUpd$PAIN_MULTI);
-			fxModArousalTaken = (float)j(data,FXCUpd$AROUSAL_MULTI);
-			
-            outputStats();
-        }
+    if(script == "got Passives" && evt == PassivesEvt$data){
+
+        FXFLAGS = (integer)jVal(data, [0]);
+		
+		integer divisor = 0;
+		if(FXFLAGS&fx$F_BLURRED){
+			divisor = 8;
+		}
+		llOwnerSay("@setdebug_renderresolutiondivisor:"+(string)divisor+"=force");
+		
+        fxModDmgTaken = (float)j(data, FXCUpd$DAMAGE_TAKEN);
+        fxModManaRegen = (float)j(data, FXCUpd$MANA_REGEN);
+		fxModPainTaken = (float)j(data,FXCUpd$PAIN_MULTI);
+		fxModArousalTaken = (float)j(data,FXCUpd$AROUSAL_MULTI);
+		
+		fxModMaxHpPerc = (float)j(data, FXCUpd$HP_MULTIPLIER);
+		fxModMaxHpNr = (int)j(data, FXCUpd$HP_ADD);
+		fxModMaxManaPerc = (float)j(data, FXCUpd$MANA_MULTIPLIER);
+		fxModMaxManaNr = (int)j(data, FXCUpd$MANA_ADD);
+		fxModMaxArousalPerc = (float)j(data, FXCUpd$AROUSAL_MULTIPLIER);
+		fxModMaxArousalNr = (int)j(data, FXCUpd$AROUSAL_ADD);
+		fxModMaxPainPerc = (float)j(data, FXCUpd$PAIN_MULTIPLIER);
+		fxModMaxPainNr = (int)j(data, FXCUpd$PAIN_ADD);
+		
+		qd(maxDurability());
+        outputStats();
+        
     }else if(script == "#ROOT"){
         if(evt == RootEvt$players){
             PLAYERS = llJson2List(data);


### PR DESCRIPTION
Adds a new script to the HUD root prim called "got Passives". PCs will
reroute the FXCEvt through got Passives and the result will be a
combination of both through PassivesEvt$data. The parameters are exactly
the same. NPCs should be left untouched but need testing.

It also adds a handful of new things you can do with passives to modify
the max value of a resource.